### PR TITLE
Compute feature dims in StandardModel

### DIFF
--- a/deepmreye/train.py
+++ b/deepmreye/train.py
@@ -83,7 +83,8 @@ def train_model(
 
     # Get model
     if models is None:
-        model = architecture.StandardModel(X.shape[-1], opts).to(device)
+        input_shape = (X.shape[-1], X.shape[1], X.shape[2], X.shape[3])
+        model = architecture.StandardModel(input_shape, opts).to(device)
     else:
         model = models
     model_inference = model


### PR DESCRIPTION
## Summary
- build StandardModel using full input shape
- propagate dummy tensor through convolutional layers to derive feature dimensions
- update train routine to supply full shape when instantiating StandardModel

## Testing
- `pytest -k test_model_training -vv` *(fails: ModuleNotFoundError: No module named 'ants')*

------
https://chatgpt.com/codex/tasks/task_e_684a77562458832e9a2b16fd88ebfa4c